### PR TITLE
Bugfix: Plugin fails when PHP_CodeSniffer is not installed

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -115,7 +115,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function loadInstalledPaths()
     {
-        if ($this->isPHPCodeSnifferInstalled() === true ) {
+        if ($this->isPHPCodeSnifferInstalled() === true) {
             $output = $this->processBuilder
                 ->setArguments(['--config-show', 'installed_paths'])
                 ->getProcess()

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -96,7 +96,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     public function onDependenciesChangedEvent()
     {
-        if ($this->isPHPCodeSnifferInstalled() === true ) {
+        if ($this->isPHPCodeSnifferInstalled() === true) {
             $installPathCleaned = $this->cleanInstalledPaths();
             $installPathUpdated = $this->updateInstalledPaths();
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -115,18 +115,19 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function loadInstalledPaths()
     {
+        if ($this->isPHPCodeSnifferInstalled() === true ) {
+            $output = $this->processBuilder
+                ->setArguments(['--config-show', 'installed_paths'])
+                ->getProcess()
+                ->mustRun()
+                ->getOutput();
 
-        $output = $this->processBuilder
-            ->setArguments(['--config-show', 'installed_paths'])
-            ->getProcess()
-            ->mustRun()
-            ->getOutput();
+            $phpcsInstalledPaths = str_replace('installed_paths: ', '', $output);
+            $phpcsInstalledPaths = trim($phpcsInstalledPaths);
 
-        $phpcsInstalledPaths = str_replace('installed_paths: ', '', $output);
-        $phpcsInstalledPaths = trim($phpcsInstalledPaths);
-
-        if ($phpcsInstalledPaths !== '') {
-            $this->installedPaths = explode(',', $phpcsInstalledPaths);
+            if ($phpcsInstalledPaths !== '') {
+                $this->installedPaths = explode(',', $phpcsInstalledPaths);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes issue where plugin still tries to execute PHP_CodeSniffer, even if it is not installed.

In case this plugin was installed globally and PHP_CodeSniffer is not in the repository you are working on.