### PR TITLE
Removal of lgtm.co

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 2
-pattern = "(?i):shipit:|:ship:|:\\+1:|:ok_hand:|\\+1|(\\b(?:agree|okay|OK)\\b)|🚢|👍|👌"


### PR DESCRIPTION
 Enforcement is now done by Github's native required pull requests review method.