### PR TITLE
Adds static function to call the Plugin::onDependenciesChangedEvent() method

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -31,6 +31,9 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
+    const MESSAGE_RUNNING_INSTALLER = 'Running PHPCodeSniffer Composer Installer';
+    const MESSAGE_NOTHING_TO_INSTALL = 'Nothing to install or update';
+    const MESSAGE_NOT_INSTALLED = 'PHPCodeSniffer is not installed';
 
     const PACKAGE_TYPE = 'phpcodesniffer-standard';
 
@@ -119,13 +122,24 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     public function onDependenciesChangedEvent()
     {
+        $io = $this->io;
+        $isVerbose = $io->isVerbose();
+
+        if ($isVerbose) {
+            $io->write(sprintf('<info>%s</info>', self::MESSAGE_RUNNING_INSTALLER));
+        }
+
         if ($this->isPHPCodeSnifferInstalled() === true) {
             $installPathCleaned = $this->cleanInstalledPaths();
             $installPathUpdated = $this->updateInstalledPaths();
 
             if ($installPathCleaned === true || $installPathUpdated === true) {
                 $this->saveInstalledPaths();
+            } elseif ($isVerbose) {
+                $io->write(sprintf('<info>%s</info>', self::MESSAGE_NOTHING_TO_INSTALL));
             }
+        } elseif ($isVerbose) {
+            $io->write(sprintf('<info>%s</info>', self::MESSAGE_NOT_INSTALLED));
         }
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -35,6 +35,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     const MESSAGE_NOTHING_TO_INSTALL = 'Nothing to install or update';
     const MESSAGE_NOT_INSTALLED = 'PHPCodeSniffer is not installed';
 
+    const PACKAGE_NAME = 'squizlabs/php_codesniffer';
     const PACKAGE_TYPE = 'phpcodesniffer-standard';
 
     const PHPCS_CONFIG_KEY = 'installed_paths';
@@ -288,17 +289,19 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Simple check if PHP_CodeSniffer is installed.
      *
-     * @return bool PHP_CodeSniffer is installed
+     * @return bool Whether PHP_CodeSniffer is installed
      */
     private function isPHPCodeSnifferInstalled()
     {
-        // Check if PHP_CodeSniffer is actually installed
-        return (count(
-            $this
-                ->composer
-                ->getRepositoryManager()
-                ->getLocalRepository()
-                    ->findPackages('squizlabs/php_codesniffer')
-        ) !== 0);
+        $packages = $this
+            ->composer
+            ->getRepositoryManager()
+            ->getLocalRepository()
+            ->findPackages(self::PACKAGE_NAME)
+        ;
+
+        $packageCount = count($packages);
+
+        return ($packageCount !== 0);
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,7 +11,6 @@
 namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer;
 
 use Composer\Composer;
-
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
@@ -57,17 +56,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private $processBuilder;
 
-    public function setComposer($composer)
-    {
-        $this->composer = $composer;
-    }
-
     public static function run(Event $event)
     {
         $instance = new static();
 
         $composer = $event->getComposer();
-        $instance->setComposer($composer);
+        $instance->composer = $composer;
         $instance->init();
         $instance->onDependenciesChangedEvent();
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,11 +11,13 @@
 namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer;
 
 use Composer\Composer;
+
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
+use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\LogicException;
@@ -55,6 +57,21 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private $processBuilder;
 
+    public function setComposer($composer)
+    {
+        $this->composer = $composer;
+    }
+
+    public static function run(Event $event)
+    {
+        $instance = new static();
+
+        $composer = $event->getComposer();
+        $instance->setComposer($composer);
+        $instance->init();
+        $instance->onDependenciesChangedEvent();
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -67,10 +84,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         $this->composer = $composer;
         $this->io = $io;
+
+        $this->init();
+    }
+
+    public function init()
+    {
         $this->installedPaths = [];
 
         $this->processBuilder = new ProcessBuilder();
-        $this->processBuilder->setPrefix($composer->getConfig()->get('bin-dir') . DIRECTORY_SEPARATOR . 'phpcs');
+        $this->processBuilder->setPrefix($this->composer->getConfig()->get('bin-dir') . DIRECTORY_SEPARATOR . 'phpcs');
 
         $this->loadInstalledPaths();
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -82,7 +82,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->init();
     }
 
-    public function init()
+    private function init()
     {
         $this->installedPaths = [];
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -60,6 +60,18 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private $processBuilder;
 
+    /**
+     * Triggers the plugin's main functionality.
+     *
+     * Makes it possible to run the plugin as a custom command.
+     *
+     * @param Event $event
+     *
+     * @throws \InvalidArgumentException
+     * @throws LogicException
+     * @throws ProcessFailedException
+     * @throws RuntimeException
+     */
     public static function run(Event $event)
     {
         $io = $event->getIO();
@@ -89,6 +101,14 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->init();
     }
 
+    /**
+     * Prepares the plugin so it's main functionality can be run.
+     *
+     * @throws \RuntimeException
+     * @throws LogicException
+     * @throws ProcessFailedException
+     * @throws RuntimeException
+     */
     private function init()
     {
         $this->installedPaths = [];
@@ -117,6 +137,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Entry point for post install and post update events.
      *
+     * @throws \InvalidArgumentException
      * @throws RuntimeException
      * @throws LogicException
      * @throws ProcessFailedException
@@ -234,6 +255,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      * PHP_CodeSniffer and add the missing ones.
      *
      * @return bool True if changes where made, false otherwise
+     *
+     * @throws \InvalidArgumentException
      */
     private function updateInstalledPaths()
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -58,9 +58,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
     public static function run(Event $event)
     {
+        $io = $event->getIO();
+        $composer = $event->getComposer();
+
         $instance = new static();
 
-        $composer = $event->getComposer();
+        $instance->io = $io;
         $instance->composer = $composer;
         $instance->init();
         $instance->onDependenciesChangedEvent();


### PR DESCRIPTION
Fix for issue #4.

This PR expose a new method `run`. This can be use from a `composer.json` file like this:

```
{
    "name": "potherca/phpcodesniffer-composer-installer-example",
    "description": "Example to demonstrate the working of the dealerdirect/phpcodesniffer-composer-installer package.",
    "require": {
        "dealerdirect/phpcodesniffer-composer-installer": "*",
    },
    "scripts": {
        "run-phpcodesniffer-composer-installer": [
            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
        ]
    }
}
```

Beside this feature I have also done some minor code cleanup and added more message for in verbose mode.