### PR TITLE
Support existing standards packages with subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Create a composer package of your coding standard by adding a `composer.json` fi
 ```
 
 Requirements:
-* The repository may contain one or more standards. Each in their separate directory in the root of your repository.
+* The repository may contain one or more standards.
+* Each standard can have a separate directory no deeper than 3 levels from the repository root.
 * The package `type` must be `phpcodesniffer-standard`. Without this, the plugin will not trigger.
 
 [this]: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Coding-Standard-Tutorial

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -89,7 +89,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * Entry point for post install and post update events
+     * Entry point for post install and post update events.
      *
      * @throws RuntimeException
      * @throws LogicException
@@ -108,7 +108,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * Load all paths from PHP_CodeSniffer into an array
+     * Load all paths from PHP_CodeSniffer into an array.
      *
      * @throws RuntimeException
      * @throws LogicException
@@ -158,7 +158,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Iterate trough all known paths and check if they are still valid.
      *
-     * If path does not exists, is not an directory or isn't readble, the path is removed from the list.
+     * If path does not exists, is not an directory or isn't readable, the path
+     * is removed from the list.
      *
      * @return bool True if changes where made, false otherwise
      */
@@ -175,7 +176,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * Check all installed packages against the installed paths from PHP_CodeSniffer and add the missing ones.
+     * Check all installed packages against the installed paths from
+     * PHP_CodeSniffer and add the missing ones.
      *
      * @return bool True if changes where made, false otherwise
      */
@@ -206,7 +208,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * Iterates trough Composers' local repository looking for valid Coding Standard packages
+     * Iterates through Composers' local repository looking for valid Coding
+     * Standard packages.
      *
      * @return array Composer packages containing coding standard(s)
      */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -17,6 +17,7 @@ use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\ScriptEvents;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\RuntimeException;
@@ -185,9 +186,19 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         foreach ($codingStandardPackages as $package) {
             $packageInstallPath = $this->composer->getInstallationManager()->getInstallPath($package);
-            if (in_array($packageInstallPath, $this->installedPaths, true) === false) {
-                $this->installedPaths[] = $packageInstallPath;
-                $changes = true;
+            $finder = new Finder();
+            $finder->files()
+              ->ignoreVCS(true)
+              ->in($packageInstallPath)
+              ->depth('> 1')
+              ->depth('< 4')
+              ->name('ruleset.xml');
+            foreach ($finder as $ruleset) {
+                $standardsPath = dirname(dirname($ruleset));
+                if (in_array($standardsPath, $this->installedPaths, true) === false) {
+                    $this->installedPaths[] = $standardsPath;
+                    $changes = true;
+                }
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

- Search package sub-folders to a limited depth (< 4), to find PHP CodeSniffer standards
- Only add installed paths where a `ruleset.xml` exists in a standards sub-folder
- Update README to reflect requirements change
- Fix some spelling mistakes in comments

## Motivation

I want to use your excellent installer plugin with the Drupal PHP CodeSniffer standards. Their package uses a subfolder, one deeper than the repository root, which they're unable to change. I am sure there are other examples where Standards may be one or two folders deeper than the current installer allows.

## Notify

- @frenck
