### PR TITLE
Github contribution templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Ignore files for distribution archives.
+
+.editorconfig             export-ignore
+.gitattributes            export-ignore
+.gitignore                export-ignore
+.travis.yml               export-ignore
+.github                   export-ignore
+
+CONTRIBUTING.md           export-ignore

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Problem/Motivation
+
+> (Why the issue was filed)
+
+## Expected behaviour
+
+> (What you expected to happen)
+
+## Actual behaviour
+
+> (What actually happened)
+
+## Steps to reproduce
+
+> (How can someone else make/see it happen)
+
+## Proposed changes
+
+> (If you have a proposed change, workaround or fix, describe the rationale behind it)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Proposed Changes
+
+> (Describe the changes and rationale behind them)
+
+## Related Issues
+
+> ([Github link](https://help.github.com/articles/autolinked-references-and-urls/) to related issues or pull requests)


### PR DESCRIPTION
## Proposed Changes

- Ensure issues created contain appropriate detail
- Improve quality of pull request descriptions created by contributors
- Prevent Github templates and unnecessary developer files from being exported in Git archives (ie. Packagist distribution archives)

## Related Issues

#9 