### PR TITLE
Fixed #13: Incorrect coding standards search depth

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -269,7 +269,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $finder->files()
               ->ignoreVCS(true)
               ->in($packageInstallPath)
-              ->depth('> 1')
+              ->depth('>= 1')
               ->depth('< 4')
               ->name('ruleset.xml');
             foreach ($finder as $ruleset) {


### PR DESCRIPTION
## Proposed Changes

Changed coding standards starting search depth from `> 1` to `>= 1`.

## Related Issues

#13 Plugin not working correctly when sniffs install depth is equal to "1"