### PR TITLE
Added instanceof check to prevent root package from being installed

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -287,7 +287,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Iterates through Composers' local repository looking for valid Coding
      * Standard packages.
-     *
+     * 
+     * If the package is the RootPackage (the one the plugin is installed into), 
+     * the package is ignored for now since it needs a different install path logic.
+     
      * @return array Composer packages containing coding standard(s)
      */
     private function getPHPCodingStandardPackages()

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -290,7 +290,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      * 
      * If the package is the RootPackage (the one the plugin is installed into), 
      * the package is ignored for now since it needs a different install path logic.
-     
+     *
      * @return array Composer packages containing coding standard(s)
      */
     private function getPHPCodingStandardPackages()

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -302,7 +302,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             }
         );
 
-        if ($this->composer->getPackage()->getType() === self::PACKAGE_TYPE) {
+        if (!$this->composer->getPackage() instanceof \Composer\Package\RootpackageInterface && $this->composer->getPackage()->getType() === self::PACKAGE_TYPE) {
             $codingStandardPackages[] = $this->composer->getPackage();
         }
 


### PR DESCRIPTION
## Proposed Changes

The root package needs a different install path (since it's not really installed, it's already there) so right now the install fails. The instance of check prevents the package from being installed if the package has the RootPackageInterface.

## Related Issues

Fix for #19

I had some spare minutes and wanted to continue my sniff so I just fixed it online on Github so I won't mess up the formatting.
