### PR TITLE
Adds Travis-CI configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,27 @@ php:
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
+# Make sure a `bin` directory is present and does not contain PHAR files more
+# than 4 weeks old
+before_cache:
+  - mkdir -p "${HOME}/bin"
+  - find "${HOME}/bin/" -type f -name '*.phar' -mtime +28 -delete
+
 cache:
   directories:
     - "${HOME}/.composer/cache"
-
+    - "${HOME}/.npm/"
+    - "${HOME}/bin/"
 env:
   global:
     - PATH="${HOME}/bin:${PATH}"
 
 matrix:
   allow_failures:
-  - php: hhvm
-  - php: 5.5
-  - php: 5.4
-  - php: 5.3
+    - php: hhvm
+    - php: 5.5
+    - php: 5.4
+    - php: 5.3
   fast_finish: true
 
 before_install:
@@ -35,14 +42,14 @@ before_install:
   - npm set progress false
 
 install:
-  - composer global require "dealerdirect/qa-tools:*"
+  - '[[ -f "${HOME}/bin/phpcs.phar" ]] || curl -L -o "${HOME}/bin/phpcs.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar'
+  - '[[ -f "${HOME}/bin/security-checker.phar" ]] || curl -L -o "${HOME}/bin/security-checker.phar" http://get.sensiolabs.org/security-checker.phar'
   - npm install -g jsonlint
 
 script:
   - find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q
+  - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
+  - php "${HOME}/bin/phpcs.phar" --standard=psr2 src/
   - composer validate
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
-  - ~/.composer/vendor/bin/parallel-lint ./src
-  - ~/.composer/vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock
-  - ~/.composer/vendor/bin/phpcs --standard=psr2 src/
-
+  - php "${HOME}/bin/security-checker.phar" -n security:check --end-point=http://security.sensiolabs.org/check_lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
 matrix:
   allow_failures:
   - php: hhvm
+  - php: 5.5
   - php: 5.4
   - php: 5.3
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+---
+language: php
+
+php:
+  - hhvm
+  - 7.1
+  - 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+  - 5.3
+
+# This triggers builds to run on the new (faster) TravisCI infrastructure.
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+cache:
+  directories:
+    - "${HOME}/.composer/cache"
+
+env:
+  global:
+    - PATH="${HOME}/bin:${PATH}"
+
+matrix:
+  allow_failures:
+  - php: hhvm
+  - php: 5.4
+  - php: 5.3
+  fast_finish: true
+
+before_install:
+  - npm set loglevel error
+  - npm set progress false
+
+install:
+  - composer global require "dealerdirect/qa-tools:*"
+  - npm install -g jsonlint
+
+script:
+  - find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q
+  - composer validate
+  - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
+  - ~/.composer/vendor/bin/parallel-lint ./src
+  - ~/.composer/vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock
+  - ~/.composer/vendor/bin/phpcs --standard=psr2 src/
+

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -308,7 +308,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             }
         );
 
-        if (!$this->composer->getPackage() instanceof \Composer\Package\RootpackageInterface && $this->composer->getPackage()->getType() === self::PACKAGE_TYPE) {
+        if (! $this->composer->getPackage() instanceof \Composer\Package\RootpackageInterface
+            && $this->composer->getPackage()->getType() === self::PACKAGE_TYPE
+        ) {
             $codingStandardPackages[] = $this->composer->getPackage();
         }
 


### PR DESCRIPTION
## Proposed Changes

I got annoyed at all of the pull-requests having a red :x: next to builds. 

This merge request fixes that by adding a `.travis.yml` file that triggers a PHP build.
It tries to find a balance between speed and quality.

I've also added a fix for a PHP CodeSniffer violation (one line exceeded 120 characters).

## Related Issues

Part of issue #9  

## Caveats

The `dealerdirect/qa-tools` is installed on the Travis machine to run QA checks.
Currently this means the build for unsupported PHP versions (5.3, 5.4, 5.4) will fail because `qa-tools` requires at least 5.6.

At a later stage, these builds could be made to pass. Such a solution is not within scope for this merge-request.