### PR TITLE
CHANGE: Local projects uses relative paths to their coding standards

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -244,7 +244,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         $changes = false;
         foreach ($this->installedPaths as $key => $path) {
-            // This might be an relative path as well
+            // This might be a relative path as well
             $alternativePath = realpath($this->getPHPCodeSnifferInstallPath() . DIRECTORY_SEPARATOR . $path);
 
             if ((is_dir($path) === false || is_readable($path) === false) &&
@@ -394,7 +394,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         // Some compatibility fixes for Windows paths
         $from = is_dir($from) ? rtrim($from, '\/') . '/' : $from;
-        $to = is_dir($to)   ? rtrim($to, '\/') . '/'   : $to;
+        $to = is_dir($to) ? rtrim($to, '\/') . '/' : $to;
         $from = str_replace('\\', '/', $from);
         $to = str_replace('\\', '/', $to);
 


### PR DESCRIPTION
## Proposed Changes

Changed they way paths are put into PHP_CodeSniffer based on Composer being executes globally or not. Local repositories (project folder) installations will use relative paths from the PHP_CodeSniffer installation directory to the directory containing the coding standard.

The behaviour for globally installed instances will keep using absolute paths; unchanged.

## Related Issues

#20 Install sniffs with relative paths in CodeSniffer.conf