### PR TITLE
Fixes #33. Changes the way the installed_paths are set.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -286,24 +286,25 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             ->in($searchPaths);
 
         // Only version 3.x and higher has support for having coding standard in the root of the directory.
-        $allowCodingStandardsInRoot = $this->isPHPCodeSnifferInstalled('>= 3.0.0');
-
-        if ($allowCodingStandardsInRoot !== true) {
+        if ($this->isPHPCodeSnifferInstalled('>= 3.0.0') !== true) {
             $finder->depth('>= 1');
         }
 
+        // Process each found possible ruleset.
         foreach ($finder as $ruleset) {
             $standardsPath = $ruleset->getPath();
 
-            if ($allowCodingStandardsInRoot === false) {
+            // Pick the directory above the directory containing the standard, unless this is the project root.
+            if ($standardsPath !== getcwd()) {
                 $standardsPath = dirname($standardsPath);
             }
 
-            // Use relative paths for local project repositories
+            // Use relative paths for local project repositories.
             if ($this->isRunningGlobally() === false) {
                 $standardsPath = $this->getRelativePath($standardsPath);
             }
 
+            // De-duplicate and add when directory is not configured.
             if (in_array($standardsPath, $this->installedPaths, true) === false) {
                 $this->installedPaths[] = $standardsPath;
                 $changes = true;


### PR DESCRIPTION
## Proposed Changes

Changes the behavior of registering installed_paths in PHP_CodeSniffer 3.x. It will now work in the same way as was required for PHP_CodeSniffer 2.x. It will record the directory ABOVE the directory containing the coding standard. The only exception is when the root project itself provides the standard in the root of its project.

## Related Issues

> [#33 Incorrect relative paths for WPCS](#33)