### PR TITLE
Docs: Rename example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ section of the `composer.json`:
 ```json
 {
     "scripts": {
-        "install-codesniffs": [
+        "install-codestandards": [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
         ]
     }
@@ -58,17 +58,17 @@ section of the `composer.json`:
 
 ```
 
-The command can then be called using `composer run-script install-codesniffs` or 
+The command can then be called using `composer run-script install-codestandards` or 
 referenced from other script configurations, as follows:
 
 ```json
 {
     "scripts": {
-        "install-codesniffs": [
+        "install-codestandards": [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
         ],
         "post-install-cmd": [
-            "@install-codesniff"
+            "@install-codestandards"
         ]
     }
 }


### PR DESCRIPTION
The script will install (register) one or more _Standards_ to PHP CodeSniffer, not the individual _Sniffs_.

## Proposed Changes

Rename the script example in the Docs to clarify intent.

Optionally, it calls also be called `register-codestandards`, since the installation of the files has already been done by Composer, and this script would just re-register the Standard with PHP CodeSniffer. I've left it as `install-codestandards` for now though, as it may be perceived to be easier to remember, even if not technically accurate.
