### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Note: This plugin is compatible with both version 2.x and 3.x of_ [PHP_CodeSnif
 Installation can be done with [composer], by requiring this package as a development dependency:
 
 ```bash
-composer require --dev dealerdirect/phpcodesniffer-composer-installer frenck/php-compatibility
+composer require --dev dealerdirect/phpcodesniffer-composer-installer
 ```
 
 That's it.


### PR DESCRIPTION
The example on how to require the plugin includes a reference to a fork of the PHPCompatibility standard which seems out of place.

1. This plugin is AFAIK not only for that standard (though inspired by the issues it had)
2. For using the PHPCompatibility standard, the fork is no longer needed as of tomorrow with the release of v 8.0.0 which fixes the Composer related issues.

