### PR TITLE
Local PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "squizlabs/php_codesniffer": "*"
   },
   "require-dev": {
-    "composer/composer": "*"
+    "composer/composer": "*",
+    "wimg/php-compatibility": "^8.0"
   },
   "suggest": {
     "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
@@ -40,5 +41,10 @@
   },
   "extra": {
     "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+  },
+  "scripts": {
+    "install-codestandards": [
+      "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+    ]
   }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="phpcodesniffer-composer-installer">
+    <description>Coding standards for PHP_CodeSniffer Standards Composer Installer Plugin</description>
+
+    <arg name="extensions" value="php"/>
+    <!-- Show sniff codes in all reports, and progress when running -->
+    <arg value="sp"/>
+
+    <file>.</file>
+    <exclude-pattern>*/.github/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <rule ref="PHPCompatibility"/>
+    <config name="testVersion" value="5.3-"/>
+
+    <rule ref="PSR2"/>
+</ruleset>


### PR DESCRIPTION
This plugin already has PHP_CodeSniffer as a dependency, but the project itself should also be checked against code standards.

While PSR-2 is already included, it would be useful to also check that the code supports down to the PHP 5.3 version specified in the Travis CI config file.

The inclusion of the `script` is so that those developing this repo can easily register the PHPCompatibility standard.

This is a prelude to #39.