### PR TITLE
Adds the ability to set the max depth from the composer.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ in the Composer manual][composer-manual-scripts].
 
 ### Changing the Coding Standards search depth
 
-By default, this plugin searches up for Coding Standards up to four directories
+By default, this plugin searches up for Coding Standards up to three directories
 deep. In most cases, this should be sufficient. However, this plugin allows
 you to customize the search depth setting if needed.
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ referenced from other script configurations, as follows:
 For more details about Composer scripts, please refer to [the section on scripts
 in the Composer manual][composer-manual-scripts].
 
+### Changing the Coding Standards search depth
+
+By default, this plugin searches up for Coding Standards up to four directories
+deep. In most cases, this should be sufficient. However, this plugin allows
+you to customize the search depth setting if needed.
+
+```json
+{
+    "extra": {
+        "phpcodesniffer-max-depth": 5
+    }
+}
+```
+
 ### Caveats
 
 When this plugin is installed globally, composer will load the _global_ plugin rather

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ you to customize the search depth setting if needed.
 ```json
 {
     "extra": {
-        "phpcodesniffer-max-depth": 5
+        "phpcodesniffer-search-depth": 5
     }
 }
 ```

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -442,7 +442,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Determines the maximum search depth when searching for Coding Standards.
      *
-     * @return string
+     * @return int
      *
      * @throws \InvalidArgumentException
      */

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -281,20 +281,14 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $searchPaths[] = $this->composer->getInstallationManager()->getInstallPath($package);
         }
 
-        $maxDepth = $this->getMaxDepth();
-        $minDepth = $this->getMinDepth();
-
         $finder = new Finder();
         $finder->files()
             ->ignoreUnreadableDirs()
             ->ignoreVCS(true)
-            ->depth('< ' . $maxDepth)
+            ->depth('< ' . $this->getMaxDepth())
+            ->depth('>= ' . $this->getMinDepth())
             ->name('ruleset.xml')
             ->in($searchPaths);
-
-        if ($minDepth !== 0) {
-            $finder->depth('>= ' . $minDepth);
-        }
 
         // Process each found possible ruleset.
         foreach ($finder as $ruleset) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -32,11 +32,11 @@ use Symfony\Component\Process\ProcessBuilder;
  */
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
-    const ERROR_WRONG_MAX_DEPTH =
-        'The value of "%s" (in the composer.json "extra".section) must be an integer larger then %d, %s given.';
 
     const KEY_MAX_DEPTH = 'phpcodesniffer-max-depth';
 
+    const MESSAGE_ERROR_WRONG_MAX_DEPTH =
+        'The value of "%s" (in the composer.json "extra".section) must be an integer larger then %d, %s given.';
     const MESSAGE_RUNNING_INSTALLER = 'Running PHPCodeSniffer Composer Installer';
     const MESSAGE_NOTHING_TO_INSTALL = 'Nothing to install or update';
     const MESSAGE_NOT_INSTALLED = 'PHPCodeSniffer is not installed';
@@ -461,7 +461,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 || is_float($maxDepth) === true /* Within the boundaries of integer */
             ) {
                 $message = vsprintf(
-                    self::ERROR_WRONG_MAX_DEPTH,
+                    self::MESSAGE_ERROR_WRONG_MAX_DEPTH,
                     array(
                         'key' => self::KEY_MAX_DEPTH,
                         'min' => $minDepth,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -33,7 +33,7 @@ use Symfony\Component\Process\ProcessBuilder;
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
 
-    const KEY_MAX_DEPTH = 'phpcodesniffer-max-depth';
+    const KEY_MAX_DEPTH = 'phpcodesniffer-search-depth';
 
     const MESSAGE_ERROR_WRONG_MAX_DEPTH =
         'The value of "%s" (in the composer.json "extra".section) must be an integer larger then %d, %s given.';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -285,7 +285,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $finder->files()
             ->ignoreUnreadableDirs()
             ->ignoreVCS(true)
-            ->depth('< ' . $this->getMaxDepth())
+            ->depth('<= ' . $this->getMaxDepth())
             ->depth('>= ' . $this->getMinDepth())
             ->name('ruleset.xml')
             ->in($searchPaths);
@@ -448,7 +448,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function getMaxDepth()
     {
-        $maxDepth = '4';
+        $maxDepth = 3;
 
         $extra = $this->composer->getPackage()->getExtra();
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -491,12 +491,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function getMinDepth()
     {
-        $minDepth = 0;
-
         if ($this->isPHPCodeSnifferInstalled('>= 3.0.0') !== true) {
-            $minDepth = 1;
+            return 1;
         }
-
-        return $minDepth;
+        return 0;
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -446,6 +446,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
+     * Determines the maximum search depth when searching for Coding Standards.
+     *
      * @return string
      *
      * @throws \InvalidArgumentException
@@ -481,6 +483,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
+     * Returns the minimal search depth for Coding Standard packages.
+     *
+     * Usually this is 0, unless PHP_CodeSniffer >= 3 is used.
+     *
      * @return int
      */
     private function getMinDepth()


### PR DESCRIPTION
## Proposed Changes

This MR add the ability to set the max-depth of the finder from the "extra" section of the `composer.json` file. 

### Key

The name of the key is `phpcodesniffer-max-depth`. This can be changed if a better suggestion is made.

### Value

The value has the constraint that:
- It MUST be an integer (not a numeric string)
- Not smaller or equal to the minimum level (which is `0` or `1` depending on the version of PHPCS installed)
- Not so large it is converter to scientific notation (which registers as a float) as this triggers an exception from the Finder class.

If the constraint is not met an exception is thrown informing the user.

## Related Issues

Fixes #45