### PR TITLE
Move loadInstalledPaths from init to onDependenciesChangedEvent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 
 install:
   - '[[ -f "${HOME}/bin/phpcs.phar" ]] || curl -L -o "${HOME}/bin/phpcs.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar'
-  - '[[ -f "${HOME}/bin/security-checker.phar" ]] || curl -L -o "${HOME}/bin/security-checker.phar" http://get.sensiolabs.org/security-checker.phar'
+  - '[[ -f "${HOME}/bin/security-checker-v4.1.5.phar" ]] || curl -L -o "${HOME}/bin/security-checker-v4.1.5.phar" http://get.sensiolabs.org/security-checker-v4.1.5.phar'
   - npm install -g jsonlint
 
 script:
@@ -53,4 +53,4 @@ script:
   - php "${HOME}/bin/phpcs.phar" --standard=psr2 src/
   - composer validate
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
-  - php "${HOME}/bin/security-checker.phar" -n security:check --end-point=http://security.sensiolabs.org/check_lock
+  - php "${HOME}/bin/security-checker-v4.1.5.phar" -n security:check --end-point=http://security.sensiolabs.org/check_lock

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,8 +117,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         $this->processBuilder = new ProcessBuilder();
         $this->processBuilder->setPrefix($this->composer->getConfig()->get('bin-dir') . DIRECTORY_SEPARATOR . 'phpcs');
-
-        $this->loadInstalledPaths();
     }
 
     /**
@@ -154,6 +152,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         }
 
         if ($this->isPHPCodeSnifferInstalled() === true) {
+            $this->loadInstalledPaths();
             $installPathCleaned = $this->cleanInstalledPaths();
             $installPathUpdated = $this->updateInstalledPaths();
 


### PR DESCRIPTION
## Proposed Changes

The plugin executes `phpcs` when initialized, which may cause it to include the autoloader while it's in an inconsistent state.

For example, if a package that includes a static file is removed during an update (e.g. a compat library that provides global PHP functions):
1. Composer removes the outdated package from the file system
2. The phpcodesniffer-composer-installer plugin is initialized and attempts to use the autoloader files on disk
3. The outdated autoloader files on disk require the file from the removed package, and the composer update / install fails with a fatal error.

This PR moves the initialization of `installedPaths` to the method which responds to the `POST_INSTALL_CMD` and `POST_UPDATES_CMD` events, so that it is only initialized just before it's actually needed.

## Related Issues

Fixes #49 