### PR TITLE
Execute phpcs and security-checker from vendor/bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,10 @@ php:
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-# Make sure a `bin` directory is present and does not contain PHAR files more
-# than 4 weeks old
-before_cache:
-  - mkdir -p "${HOME}/bin"
-  - find "${HOME}/bin/" -type f -name '*.phar' -mtime +28 -delete
-
 cache:
   directories:
     - "${HOME}/.composer/cache"
     - "${HOME}/.npm/"
-    - "${HOME}/bin/"
 env:
   global:
     - PATH="${HOME}/bin:${PATH}"
@@ -43,14 +36,12 @@ before_install:
   - npm set progress false
 
 install:
-  - '[[ -f "${HOME}/bin/phpcs.phar" ]] || curl -L -o "${HOME}/bin/phpcs.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar'
-  - '[[ -f "${HOME}/bin/security-checker.phar" ]] || curl -L -o "${HOME}/bin/security-checker.phar" http://get.sensiolabs.org/security-checker.phar'
   - npm install -g jsonlint
 
 script:
   - find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q
   - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
-  - php "${HOME}/bin/phpcs.phar" --standard=psr2 src/
   - composer validate
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
-  - php "${HOME}/bin/security-checker.phar" -n security:check --end-point=http://security.sensiolabs.org/check_lock
+  - ./vendor/bin/phpcs --standard=psr2 src/
+  - ./vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   },
   "require-dev": {
     "composer/composer": "*",
+    "sensiolabs/security-checker": "4.1.5",
     "wimg/php-compatibility": "^8.0"
   },
   "suggest": {


### PR DESCRIPTION
## Proposed Changes

sensiolabs/security-checker introduced a change in 4.1.6 that makes the phar only compatible with PHP 7.1+

1. Use composer to manage the required version of security-checker instead of downloading via curl
2. Execute `phpcs` and `security-checker` from `/vendor/bin` instead of the phar files.

## Related Issues

- #49 
- sensiolabs/security-checker#103