### PR TITLE
Build/PHPCS: update PHPCompatibility repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ multiple `phpcodesniffer-standard` packages.
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "object-calisthenics/phpcs-calisthenics-rules": "*",
-        "wimg/php-compatibility": "*",
+        "phpcompatibility/php-compatibility": "*",
         "wp-coding-standards/wpcs": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "require-dev": {
     "composer/composer": "*",
-    "wimg/php-compatibility": "^8.0"
+    "phpcompatibility/php-compatibility": "^8.0"
   },
   "suggest": {
     "dealerdirect/qa-tools": "All the PHP QA tools you'll need"


### PR DESCRIPTION
## Proposed Changes

Switches the `PHPCompatibility` dependency over to use the repo in the `PHPCompatibility` GitHub organisation rather than the one in `wimg`'s personal account.

Includes updating the reference to the repo in the `Readme.md` file.

## Related Issues (References)

* https://github.com/PHPCompatibility/PHPCompatibility/issues/688
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/8.2.0
