### PR TITLE
PHPCS: various minor tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 .github                   export-ignore
 
 CONTRIBUTING.md           export-ignore
+phpcs.xml.dist            export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 composer.lock
+.phpcs.xml
+phpcs.xml

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,8 @@
     <arg name="extensions" value="php"/>
     <!-- Show sniff codes in all reports, and progress when running -->
     <arg value="sp"/>
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="."/>
 
     <file>.</file>
     <exclude-pattern>*/.github/*</exclude-pattern>


### PR DESCRIPTION
## Proposed Changes

* Add the PHPCS custom ruleset to the `export-ignore` list in `.gitattributes`.
* Add the files which can be used by individual devs to overrule the project PHPCS ruleset to the `.gitignore` file.
* Strip down the file paths PHPCS shows in reports to the path relative to the project root.

