### PR TITLE
Travis: various tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,10 @@ php:
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-# Make sure a `bin` directory is present and does not contain PHAR files more
-# than 4 weeks old
-before_cache:
-  - mkdir -p "${HOME}/bin"
-  - find "${HOME}/bin/" -type f -name '*.phar' -mtime +28 -delete
-
 cache:
   directories:
     - "${HOME}/.composer/cache"
     - "${HOME}/.npm/"
-    - "${HOME}/bin/"
 env:
   global:
     - PATH="${HOME}/bin:${PATH}"
@@ -43,14 +36,12 @@ before_install:
   - npm set progress false
 
 install:
-  - '[[ -f "${HOME}/bin/phpcs.phar" ]] || curl -L -o "${HOME}/bin/phpcs.phar" https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar'
-  - '[[ -f "${HOME}/bin/security-checker.phar" ]] || curl -L -o "${HOME}/bin/security-checker.phar" http://get.sensiolabs.org/security-checker.phar'
   - npm install -g jsonlint
 
 script:
   - find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q
   - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
-  - php "${HOME}/bin/phpcs.phar" --standard=psr2 src/
   - composer validate
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
-  - php "${HOME}/bin/security-checker.phar" -n security:check --end-point=http://security.sensiolabs.org/check_lock
+  - ./vendor/bin/phpcs --standard=psr2 src/
+  - ./vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ language: php
 
 php:
   - hhvm
-  - 7.2
   - 7.1
   - 7.0
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
 
 # This triggers builds to run on the new (faster) TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -24,11 +22,16 @@ env:
     - PATH="${HOME}/bin:${PATH}"
 
 matrix:
+  include:
+    - php: 7.2
+      env: SNIFF=1
+    - php: 5.3
+      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
+      dist: precise
+
   allow_failures:
     - php: hhvm
-    - php: 5.5
-    - php: 5.4
-    - php: 5.3
+
   fast_finish: true
 
 before_install:
@@ -43,5 +46,6 @@ script:
   - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
   - composer validate
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
-  - ./vendor/bin/phpcs --standard=psr2 src/
+  - if [[ "$SNIFF" == "1" ]]; then composer install-codestandards; fi
+  - if [[ "$SNIFF" == "1" ]]; then ./vendor/bin/phpcs; fi
   - ./vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   },
   "require-dev": {
     "composer/composer": "*",
+    "sensiolabs/security-checker": "4.1.5",
     "wimg/php-compatibility": "^8.0"
   },
   "suggest": {


### PR DESCRIPTION
:warning: PR #52 is a pre-requisite for this PR :warning:

This PR builds onto the changes made in PR #52 by @gapple and PR #52 should be merged first (if accepted). After that, this PR should be rebased to make it mergeable. Please feel free to ping me to rebase.

## Proposed Changes

* Fix the PHP 5.3 build by instructing Travis to use the `precise` image instead of the `trusty` image for which PHP 5.3 is no longer available.
* Don't allow the PHP 5.3/5.4/5.5 builds to fail. After PR 52, they shouldn't be failing anymore, so there's no need to allow them to fail.
* Run the PHPCS code style and cross-version compatibility check only once.
    All PHPCS sniffs are unit tested and written to give the same results on all supported PHP versions, so there is no need for the PHPCS check to be run on each and every build.
    Using the `SNIFF` environment variable, the PHPCS check is now run only on the PHP 7.2 build.
* Remove the command-line parameters from the PHPCS command.
    All relevant settings are already contained in the `phpcs.xml.dist` file and PHPCS will automatically use that file if found, so there is no need to pass these parameters on the command-line.
   N.B.: Previously, i.e. pre-PR #52, the PHPCS check would have been run before the `composer install` which meant that the `PHPCompatibility` standard used would not (yet) be available.
    As PR #52, changed the order in which these commands are run, the `PHPCompatibility` standard should now be available at the time of running PHPCS.

----

N.B.: The `composer install` command which is part of the script appears to exit with a time-out at the moment. This is unrelated to this PR, but may need attention.
```bash
$ travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
....
Generating optimized autoload files
/home/travis/.travis/job_stages: line 199:  3273 Terminated              travis_jigger $! $timeout $cmd
```