### PR TITLE
Use PHPCompatibility 9.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   "require-dev": {
     "composer/composer": "*",
     "sensiolabs/security-checker": "^4.1.0",
-    "phpcompatibility/php-compatibility": "^8.0"
+    "phpcompatibility/php-compatibility": "^9.0"
   },
   "suggest": {
     "dealerdirect/qa-tools": "All the PHP QA tools you'll need"


### PR DESCRIPTION
## Proposed Changes

[PHPCompatibility 9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) has just been released.
See the [release notes](https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/9.0.0) for all the changes, but most notably:
* All existing sniffs have been renamed.
* The release contains 17 (!!) new sniffs to detect even more issues.
* The release contains checks for a lot of PHP 7.3 changes.

The upgrade for this repo is simple as it currently doesn't use PHPCS inline annotations which reference PHPCompatibility sniffs, nor uses custom excludes.
