### PR TITLE
Support PHP CodeSniffer standards in packages installed outside of the vendor directory.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -279,8 +279,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $searchPaths = array($cwd);
         $codingStandardPackages = $this->getPHPCodingStandardPackages();
         foreach ($codingStandardPackages as $package) {
-          $installPath = $this->composer->getInstallationManager()->getInstallPath($package);
-          $searchPaths[] = $fileSystem->isAbsolutePath($installPath) ? $installPath : ($cwd . DIRECTORY_SEPARATOR . $installPath);
+            $installPath = $this->composer->getInstallationManager()->getInstallPath($package);
+            $searchPaths[] = $fileSystem->isAbsolutePath($installPath) ? $installPath : ($cwd . DIRECTORY_SEPARATOR . $installPath);
         }
 
         $finder = new Finder();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -280,7 +280,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $codingStandardPackages = $this->getPHPCodingStandardPackages();
         foreach ($codingStandardPackages as $package) {
             $installPath = $this->composer->getInstallationManager()->getInstallPath($package);
-            $searchPaths[] = $fileSystem->isAbsolutePath($installPath) ? $installPath : ($cwd . DIRECTORY_SEPARATOR . $installPath);
+            if (!$fileSystem->isAbsolutePath($installPath)) {
+                $installPath = $cwd . DIRECTORY_SEPARATOR . $installPath;
+            }
+            $searchPaths[] = $installPath;
         }
 
         $finder = new Finder();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,6 +19,7 @@ use Composer\Package\RootpackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
+use Composer\Util\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\LogicException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -271,10 +272,15 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         $changes = false;
 
-        $searchPaths = array(getcwd());
+        $cwd = getcwd();
+
+        $fileSystem = new Filesystem();
+
+        $searchPaths = array($cwd);
         $codingStandardPackages = $this->getPHPCodingStandardPackages();
         foreach ($codingStandardPackages as $package) {
-            $searchPaths[] = $this->composer->getInstallationManager()->getInstallPath($package);
+          $installPath = $this->composer->getInstallationManager()->getInstallPath($package);
+          $searchPaths[] = $fileSystem->isAbsolutePath($installPath) ? $installPath : ($cwd . DIRECTORY_SEPARATOR . $installPath);
         }
 
         $finder = new Finder();


### PR DESCRIPTION
## Proposed Changes

> The aim of this change is to add support for PHP CodeSniffer standards in packages installed outside of the vendor directory. One such example is [Drupal's Coder module](https://www.drupal.org/project/coder) which is most commonly installed into ``web/sites/all/modules/contributed/coder`` where the ``web`` directory is on the same level as ``vendor``.

## Related Issues

> [#63]