### PR TITLE
Removes HHVM from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: php
 
 php:
-  - hhvm
   - 7.3
   - 7.1
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ matrix:
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
 
-  allow_failures:
-    - php: hhvm
-
   fast_finish: true
 
 before_install:


### PR DESCRIPTION
## Proposed Changes

Removes checks against HHVM from TravisCI.

Reasoning:
- HHVM builds are failing
- Almost impossible to fix
- HHVM discourages the use of HHVM for PHP projects

Source: https://github.com/facebook/hhvm#hhvm
> HHVM is intended for Hack projects, and also supports a large subset of PHP 7 that is required by common tools and libraries. We no longer recommend using HHVM for purely PHP projects.


## Related Issues

n/a
