### PR TITLE
Adds PHP_CodeSniffer version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": "^5.3|^7",
     "composer-plugin-api": "^1.0",
-    "squizlabs/php_codesniffer": "*"
+    "squizlabs/php_codesniffer": "^2|^3"
   },
   "require-dev": {
     "composer/composer": "*",


### PR DESCRIPTION
## Proposed Changes

From TravisCI build ouput:

```
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
require.squizlabs/php_codesniffer : unbound version constraints (*) should be avoided
```

This PR adds version constraints to avoid that warning. Also, this plugin is currently only compatible with 2.x and 3.x of PHP_CodeSniffer.

## Related Issues

n/a