### PR TITLE
Respect PHP version used by Composer and provide better feedback on failure

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -238,9 +238,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             );
         }
 
-        $this->io->write($configMessage);
-
-        $this->processExecutor->execute(
+        $exitCode = $this->processExecutor->execute(
             sprintf(
                 'phpcs %s',
                 implode(' ', $arguments)
@@ -248,6 +246,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $configResult,
             $this->composer->getConfig()->get('bin-dir')
         );
+
+        if ($exitCode === 0) {
+            $this->io->write($configMessage);
+        } else {
+            $failMessage = sprintf(
+                'Failed to set PHP CodeSniffer <info>%s</info> Config',
+                self::PHPCS_CONFIG_KEY
+            );
+            $this->io->write($failMessage);
+        }
 
         if ($this->io->isVerbose() && !empty($configResult)) {
             $this->io->write(sprintf('<info>%s</info>', $configResult));

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -245,17 +245,27 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             self::PHPCS_CONFIG_KEY
         );
 
-        // Okay, lets rock! 🤘
-        $command = vsprintf('%s ./bin/phpcs %s', array(
-            'php executable' => $this->getPhpExecCommand(),
-            'arguments' => implode(' ', $arguments)
-        ));
+        // Determine the path to the main PHPCS file.
+        $phpcsPath = $this->getPHPCodeSnifferInstallPath();
+        if (file_exists($phpcsPath . '/bin/phpcs') === true) {
+            // PHPCS 3.x.
+            $phpcsExecutable = './bin/phpcs';
+        } else {
+            // PHPCS 2.x.
+            $phpcsExecutable = './scripts/phpcs';
+        }
 
-        $exitCode = $this->processExecutor->execute(
-            $command,
-            $configResult,
-            $this->getPHPCodeSnifferInstallPath()
+        // Okay, lets rock!
+        $command = vsprintf(
+            '%s %s %s',
+            array(
+                'php executable'   => $this->getPhpExecCommand(),
+                'phpcs executable' => $phpcsExecutable,
+                'arguments'        => implode(' ', $arguments)
+            )
         );
+
+        $exitCode = $this->processExecutor->execute($command, $configResult, $phpcsPath);
 
         if ($exitCode === 0) {
             $this->io->write($configMessage);


### PR DESCRIPTION
## Proposed Changes

### Improve feedback to user on failure to set paths

Related to #79.

When the setting of `installed_paths` fails, show an error instead of giving the impression that the setting of the `installed_paths` succeeded.

### Use the PHP version used by Composer

Possibly not the best way to do this, but it does work, so consider this a proof of concept, if not the solution.

The `getPhpExecCommand()` method in the `Composer\EventDispatcher\EventDispatcher` class basically does what is needed: find the PHP executable used by Composer and turn it into an executable command.

Unfortunately, that method is `protected`, making it difficult to call that method from within the plugin.

This now copies that method into the plugin and uses it to create the command to pass on to the `ProcessExecutor`.

The copied method has some minor modifications to comply with the coding standards used within this project.

Based on the proof of conflict referenced in #79, I can confirm that this would solve the issue.

## Related Issues

Fixes #79