### PR TITLE
Update Travis file and fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ php:
   - 7.1
   - 7.0
   - 5.6
-  - 5.5
-  - 5.4
-
-# This triggers builds to run on the new (faster) TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
 
 cache:
   directories:
@@ -25,8 +19,14 @@ matrix:
   include:
     - php: 7.2
       env: SNIFF=1
+    - php: 5.5
+      # As the latest Debian does not support PHP 5.5 anymore, we need to force using 'trusty'.
+      dist: trusty
+    - php: 5.4
+      # As the latest Debian does not support PHP 5.4 anymore, we need to force using 'trusty'.
+      dist: trusty
     - php: 5.3
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
+      # As the latest Debian does not support PHP 5.3 anymore, we need to force using 'precise'.
       dist: precise
 
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ script:
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
   - if [[ "$SNIFF" == "1" ]]; then composer install-codestandards; fi
   - if [[ "$SNIFF" == "1" ]]; then ./vendor/bin/phpcs; fi
-  - ./vendor/bin/security-checker -n security:check --end-point=http://security.sensiolabs.org/check_lock
+  - ./vendor/bin/security-checker -n security:check --end-point=http://security.symfony.com/check_lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: php
 
 php:
-  - 7.3
+  - 7.2
   - 7.1
   - 7.0
   - 5.6
@@ -17,7 +17,7 @@ env:
 
 matrix:
   include:
-    - php: 7.2
+    - php: 7.3
       env: SNIFF=1
     - php: 5.5
       # As the latest Debian does not support PHP 5.5 anymore, we need to force using 'trusty'.
@@ -39,10 +39,11 @@ install:
   - npm install -g jsonlint
 
 script:
-  - find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q
-  - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
-  - composer validate
+  - if [[ "$SNIFF" == "1" ]];then find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q; fi
+  - if [[ "$SNIFF" == "1" ]];then find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l; fi
+  - if [[ "$SNIFF" == "1" ]];then composer validate; fi
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
-  - if [[ "$SNIFF" == "1" ]]; then composer install-codestandards; fi
-  - if [[ "$SNIFF" == "1" ]]; then ./vendor/bin/phpcs; fi
-  - ./vendor/bin/security-checker -n security:check --end-point=http://security.symfony.com/check_lock
+  - composer install-codestandards
+  - ./vendor/bin/phpcs -i
+  - ./vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --exclude=PHPCompatibility.Upgrade.LowPHP ./src/
+  - if [[ "$SNIFF" == "1" ]];then ./vendor/bin/security-checker -n security:check --end-point=http://security.symfony.com/check_lock; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 ---
 language: php
 
-php:
-  - 7.2
-  - 7.1
-  - 7.0
-  - 5.6
-
 cache:
   directories:
     - "${HOME}/.composer/cache"
@@ -15,12 +9,29 @@ env:
   global:
     - PATH="${HOME}/bin:${PATH}"
 
-matrix:
+jobs:
   include:
-    - php: 7.4snapshot
+    - php: 7.3
+      name: Linting
+      stage: lint
+      before_install:
+        - npm set loglevel error
+        - npm set progress false
+      install:
+        - npm install -g jsonlint
+      script:
+        - find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q
+        - composer validate
+
+    - stage: test
+      php: 7.4snapshot
       allow_failures: true
     - php: 7.3
-      env: SNIFF=1
+      env: SECURITY=1
+    - php: 7.2
+    - php: 7.1
+    - php: 7.0
+    - php: 5.6
     - php: 5.5
       # As the latest Debian does not support PHP 5.5 anymore, we need to force using 'trusty'.
       dist: trusty
@@ -30,22 +41,19 @@ matrix:
     - php: 5.3
       # As the latest Debian does not support PHP 5.3 anymore, we need to force using 'precise'.
       dist: precise
+      script:
+        - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
+        - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
+        - composer install-codestandards
+        - ./vendor/bin/phpcs -i
+        - ./vendor/bin/phpcs -s --standard=PHPCompatibility --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --exclude=PHPCompatibility.Upgrade.LowPHP ./src/
 
   fast_finish: true
 
-before_install:
-  - npm set loglevel error
-  - npm set progress false
-
-install:
-  - npm install -g jsonlint
-
 script:
-  - if [[ "$SNIFF" == "1" ]];then find . -type f -name "*.json" -print0 | xargs -0 -n1 jsonlint -q; fi
-  - if [[ "$SNIFF" == "1" ]];then find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l; fi
-  - if [[ "$SNIFF" == "1" ]];then composer validate; fi
+  - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
   - composer install-codestandards
   - ./vendor/bin/phpcs -i
-  - ./vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --exclude=PHPCompatibility.Upgrade.LowPHP ./src/
-  - if [[ "$SNIFF" == "1" ]];then ./vendor/bin/security-checker -n security:check --end-point=http://security.symfony.com/check_lock; fi
+  - ./vendor/bin/phpcs -s --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --exclude=PHPCompatibility.Upgrade.LowPHP ./src/
+  - if [[ "$SECURITY" == "1" ]];then ./vendor/bin/security-checker -n security:check --end-point=http://security.symfony.com/check_lock; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
 
 matrix:
   include:
+    - php: 7.4snapshot
+      allow_failures: true
     - php: 7.3
       env: SNIFF=1
     - php: 5.5


### PR DESCRIPTION
## Proposed Changes

Currently the Travis build is breaking because the URL used by the security-checker no longer exists.
This MR updates that URL to the new home in order to fix the build.

It also adds a preview for PHP 7.4 and makes minor changes to improve the build step.