### PR TITLE
CS: fix compliance with PSR12

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,5 +15,9 @@
     <rule ref="PHPCompatibility"/>
     <config name="testVersion" value="5.3-"/>
 
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <!-- Constant visibility can not be declared (yet) as the minimum supported PHP version is 5.3
+             and constant visibility was only introduced in PHP 7.1. -->
+        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
+    </rule>
 </ruleset>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -269,7 +269,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             // This might be a relative path as well
             $alternativePath = realpath($this->getPHPCodeSnifferInstallPath() . DIRECTORY_SEPARATOR . $path);
 
-            if ((is_dir($path) === false || is_readable($path) === false) &&
+            if (
+                (is_dir($path) === false || is_readable($path) === false) &&
                 (is_dir($alternativePath) === false || is_readable($alternativePath) === false)
             ) {
                 unset($this->installedPaths[$key]);
@@ -362,7 +363,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             }
         );
 
-        if (! $this->composer->getPackage() instanceof RootpackageInterface
+        if (
+            ! $this->composer->getPackage() instanceof RootpackageInterface
             && $this->composer->getPackage()->getType() === self::PACKAGE_TYPE
         ) {
             $codingStandardPackages[] = $this->composer->getPackage();
@@ -441,7 +443,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $maxDepth = $extra[self::KEY_MAX_DEPTH];
             $minDepth = $this->getMinDepth();
 
-            if ((string) (int) $maxDepth !== (string) $maxDepth /* Must be an integer or cleanly castable to one */
+            if (
+                (string) (int) $maxDepth !== (string) $maxDepth /* Must be an integer or cleanly castable to one */
                 || $maxDepth <= $minDepth                       /* Larger than the minimum */
                 || is_float($maxDepth) === true                 /* Within the boundaries of integer */
             ) {


### PR DESCRIPTION
## Proposed Changes

PHPCS 3.5.0+ contains a far more complete PSR12 ruleset.

1. The current code didn't fully comply with that ruleset. Some minor code tweaks fix that.
2. PSR12 demands constant visibility to be declared, but as this project still supports PHP 5.3 and constant visibility wasn't introduced until PHP 7.1, this is not desirable. Excluding that particular rule from within the ruleset fixes that.

## Related Issues

* https://github.com/squizlabs/php_codesniffer/releases
