### PR TITLE
Travis: test against PHP 7.4, not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ jobs:
         - composer validate
 
     - stage: test
-      php: 7.4snapshot
-      allow_failures: true
+      php: 7.4
     - php: 7.3
       env: SECURITY=1
     - php: 7.2


### PR DESCRIPTION
## Proposed Changes

Looks like Travis (finally) has got a "normal" PHP 7.4 image available.

Also, as PHP 7.4 has been released, don't allow failures for 7.4 anymore.
