### PR TITLE
Travis: use a mix of PHPCS versions in the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - "${HOME}/.composer/cache"
     - "${HOME}/.npm/"
+
 env:
   global:
     - PATH="${HOME}/bin:${PATH}"
@@ -25,27 +26,56 @@ jobs:
 
     - stage: test
       php: 7.4
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 7.4
+      # Lowest PHPCS version on which PHP 7.4 is supported.
+      env: PHPCS_VERSION="3.5.0"
     - php: 7.3
-      env: SECURITY=1
+      env: SECURITY=1 PHPCS_VERSION="3.5.3" LINT=1 PHPCS=1
+    - php: 7.3
+      # Lowest PHPCS version on which PHP 7.3 is supported.
+      env: PHPCS_VERSION="3.3.1"
     - php: 7.2
+      env: PHPCS_VERSION="3.2.3" LINT=1
+    - php: 7.2
+      # Lowest PHPCS version on which PHP 7.2 is supported.
+      env: PHPCS_VERSION="2.9.2"
     - php: 7.1
+      env: PHPCS_VERSION="3.1.1" LINT=1
+    - php: 7.1
+      env: PHPCS_VERSION="2.0.0"
     - php: 7.0
+      env: PHPCS_VERSION="3.4.2" LINT=1
+    - php: 7.0
+      env: PHPCS_VERSION="2.2.0"
     - php: 5.6
+      env: PHPCS_VERSION="3.0.2" LINT=1
+    - php: 5.6
+      env: PHPCS_VERSION="2.4.0"
     - php: 5.5
       # As the latest Debian does not support PHP 5.5 anymore, we need to force using 'trusty'.
       dist: trusty
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 5.5
+      # As the latest Debian does not support PHP 5.5 anymore, we need to force using 'trusty'.
+      dist: trusty
+      env: PHPCS_VERSION="2.6.1"
     - php: 5.4
       # As the latest Debian does not support PHP 5.4 anymore, we need to force using 'trusty'.
       dist: trusty
+      env: PHPCS_VERSION="3.5.3" LINT=1
+    - php: 5.4
+      # As the latest Debian does not support PHP 5.4 anymore, we need to force using 'trusty'.
+      dist: trusty
+      env: PHPCS_VERSION="2.8.1"
     - php: 5.3
       # As the latest Debian does not support PHP 5.3 anymore, we need to force using 'precise'.
       dist: precise
-      script:
-        - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
-        - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
-        - composer install-codestandards
-        - ./vendor/bin/phpcs -i
-        - ./vendor/bin/phpcs -s --standard=PHPCompatibility --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --exclude=PHPCompatibility.Upgrade.LowPHP ./src/
+      env: PHPCS_VERSION="2.9.2"
+    - php: 5.3
+      # As the latest Debian does not support PHP 5.3 anymore, we need to force using 'precise'.
+      dist: precise
+      env: PHPCS_VERSION="2.0.0"
 
   fast_finish: true
 
@@ -53,10 +83,36 @@ before_install:
   # Speed up build time by disabling Xdebug.
   phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
-script:
-  - find . -type f -name "*.php" -print0 | xargs -0 -n1 php -l
+install:
+  - composer require --no-update --no-suggest --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
+  - |
+    if [[ ${PHPCS_VERSION:0:3} < "2.2" ]]; then
+      # Install PHPCompatibility 7.x for PHPCS < 2.2.
+      composer require --no-update --no-suggest --no-scripts phpcompatibility/php-compatibility:"^7.0"
+    elif [[ ${PHPCS_VERSION:0:3} < "2.3" ]]; then
+      # Install PHPCompatibility 8.x for PHPCS 2.2 < 2.3.
+      composer require --no-update --no-suggest --no-scripts phpcompatibility/php-compatibility:"^8.0"
+    fi
   - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
+  - |
+    if [[ ${PHPCS_VERSION:0:3} < "2.2" ]]; then
+      # Rename the PHPCompatibility directory as PHPCompatibility 7.x wasn't fully compatible with Composer yet.
+      mv ./vendor/phpcompatibility/php-compatibility ./vendor/phpcompatibility/PHPCompatibility
+    fi
+
+script:
+  - if [[ "$LINT" == "1" ]]; then if find . -path ./vendor -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
   - composer install-codestandards
   - ./vendor/bin/phpcs -i
-  - ./vendor/bin/phpcs -s --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --exclude=PHPCompatibility.Upgrade.LowPHP ./src/
+  - |
+    if [[ "$PHPCS" == "1" ]]; then
+      # Do the actual code style check for this repo.
+      ./vendor/bin/phpcs
+    elif [[ ${PHPCS_VERSION:0:3} < "2.3" ]]; then
+      # Test that an external standard has been registered correctly by running it against the codebase on PHPCS < 2.3.
+      ./vendor/bin/phpcs -ps ./src/ --standard=PHPCompatibility --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --sniffs=PHPCompatibility.PHP.DeprecatedFunctions
+    else
+      # Test that an external standard has been registered correctly by running it against the codebase.
+      ./vendor/bin/phpcs -ps ./src/ --standard=PHPCompatibility --runtime-set testVersion "${TRAVIS_PHP_VERSION:0:3}" --sniffs=PHPCompatibility.FunctionUse.RemovedFunctions
+    fi
   - if [[ "$SECURITY" == "1" ]];then ./vendor/bin/security-checker -n security:check --end-point=http://security.symfony.com/check_lock; fi


### PR DESCRIPTION
## Proposed Changes

Using a normal `composer install` means that while the build was testing against various PHP versions, it would only ever test against the latest PHPCS 3.x version (`3.5.3` at the time of writing) for PHP 5.4-7.4 and PHPCS 2.9.2 for PHP 5.3.

This PR changes the build matrix to test against a variety of PHPCS versions to try to ensure compatibility with all versions this plugin claims to support.

Some explanation is needed about the choices made in this changeset:

### Adding an `install` section

The `install` section is intended for installing prerequisites for test build tests.

AFAICS, this wasn't previously used to avoid the PHP `lint` command running over the `vendor` directory, but that can be solved by just removing the `vendor` directory from the list PHP `lint` is run over.

Having the install instructions in the `install` section makes it clearer that the installation is not part of the tests and what's being installed.

### Changes to the PHP `lint` command

As mentioned above, the command now excludes the `vendor` directory.

Also, as most PHP versions now have a second build, adding a `LINT` environment variable so the PHP linting is only done on one build per PHP version.

### Changes to the PHPCS run test command

The PSR12 ruleset which is part of the `phpcs.xml.dist` ruleset was only added in PHPCS 3.3.0.

As testing is now done against a wider range of PHPCS versions, this `PSR12` ruleset won't always be available, so I've added a `PHPCS` environment variable to only run the PHPCS check against the repo specific ruleset _once_ per build.

I've added this variable to a build against the latest PHPCS version. While I'd like to use `dev-master` for this, that may be prone to intermittent bugs in PHPCS, so using a stable PHPCS version instead makes the build more sane.

On all the other builds, only a check against `PHPCompatibility` is run which then tests whether the setting of the `installed_paths` for external standards worked correctly.

Now there are two caveats to this:
* PHPCompatibility 9.0.0 dropped support for PHPCS < 2.3.0.
    For testing against PHPCS 2.2.0 - 2.3.0 we need to explicitly install PHPCompatibility 8.x.
    For testing against PHPCS < 2.2.0 we need to explicitly install PHPCompatibility 7.x, however PHPCompatibility 7.x wasn't compatible with Composer installs yet, so in that case we also need to rename the directory within `vendor` to make things work.
    Note/advance notice: PHPCompatibility 10.0.0, which is expected over the next few months, will drop support for PHPCS < 2.6.0 and PHP < 5.4.
    Also see: https://github.com/PHPCompatibility/PHPCompatibility/issues/835
* The PHPCS `--exclude` option previously used to exclude the `PHPCompatibility.Upgrade.LowPHPCS` sniff is only available since PHPCS 2.6.2, so cannot be used to exclude that sniff on older PHPCS versions.
    With that in mind, switching to using the `--sniffs=` command line option to limit the PHPCS run to just one sniff.
    This option has been available since PHPCS 1.x (or even before), so can be used without problem.
    Additionally, limiting the test run to just one sniff will make it faster as well.
    I've just selected one of the sniffs from PHPCompatibility which has been around for a while for this. The actual sniff doesn't matter after all, as this test is just about PHPCS recognizing the external standard correctly.

### Custom PHP 5.3 script

As the script for the PHPCS run has changed now, there is no need for the custom `script` section for the PHP 5.3 build anymore. This can now revert back to using the normal test `script` again, so to that end, I've remove the custom script.

## Future improvements

This is a first iteration to improve the build script.

In a further iteration, I'd like to suggest exploring the following additional variants:
* Having some builds with a global install of PHPCS + global install of the external standard used for testing.
* Having some builds with a mix of global/local installs of external standards(s).
* Having some builds using Windows as OS instead of Linux.

