### PR TITLE
Send an exit code when the script terminates

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -180,9 +180,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             } elseif ($isVerbose) {
                 $io->write(sprintf('<info>%s</info>', self::MESSAGE_NOTHING_TO_INSTALL));
             }
-        } elseif ($isVerbose) {
-            $io->write(sprintf('<info>%s</info>', self::MESSAGE_NOT_INSTALLED));
+        } else {
             $exitCode = 1;
+            if ($isVerbose) {
+                $io->write(sprintf('<info>%s</info>', self::MESSAGE_NOT_INSTALLED));
+            }
         }
 
         exit($exitCode);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -164,6 +164,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         $io = $this->io;
         $isVerbose = $io->isVerbose();
+        $exitCode = 0;
 
         if ($isVerbose) {
             $io->write(sprintf('<info>%s</info>', self::MESSAGE_RUNNING_INSTALLER));
@@ -175,13 +176,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $installPathUpdated = $this->updateInstalledPaths();
 
             if ($installPathCleaned === true || $installPathUpdated === true) {
-                $this->saveInstalledPaths();
+                $exitCode = $this->saveInstalledPaths();
             } elseif ($isVerbose) {
                 $io->write(sprintf('<info>%s</info>', self::MESSAGE_NOTHING_TO_INSTALL));
             }
         } elseif ($isVerbose) {
             $io->write(sprintf('<info>%s</info>', self::MESSAGE_NOT_INSTALLED));
+            $exitCode = 1;
         }
+
+        exit($exitCode);
     }
 
     /**
@@ -218,6 +222,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      * @throws LogicException
      * @throws ProcessFailedException
      * @throws RuntimeException
+     *
+     * @return int Exit code. 0 for success, 1 or higher for failure.
      */
     private function saveInstalledPaths()
     {
@@ -276,6 +282,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         if ($this->io->isVerbose() && !empty($configResult)) {
             $this->io->write(sprintf('<info>%s</info>', $configResult));
         }
+
+        return $exitCode;
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

This fixes the issue identified in https://github.com/Dealerdirect/phpcodesniffer-composer-installer/pull/80#issuecomment-531586417 where even when the setting of `installed_paths` failed, the plugin would exit with exit code `0`.

A `0` exit code will be returned if successful, `1` - or the exit code returned by PHPCS itself - if not.

This will allow wrapper scripts and/or process scripts which take exit codes into account to fail correctly and/or notify users of failure.


## Testing this change

1. On this repo, throw away the `vendor` directory and `composer.lock` file.
2. Make sure you are on the `master` branch.
3. Run `composer install`.
4. Now for the sake of testing this change, copy the `vendor/squizlabs/php_codesniffer/CodeSniffer.conf.dist` file to `vendor/squizlabs/php_codesniffer/CodeSniffer.conf` and make it `read only`.
5. Now run `composer install-codestandards --verbose`.
    The output will look something like:
    ```
    Composer version 1.9.1 2019-11-01 17:20:17

    > install-codestandards: Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin::run
    Running PHPCodeSniffer Composer Installer
    Failed to set PHP CodeSniffer installed_paths Config
    ERROR: Config file I:\path\to\phpcodesniffer-composer-installer\vendor\squizlabs\php_codesniffer\CodeSniffer.conf is not writable
    ```
6. Run `echo $?` and take note of the exit code being `0` (= success).
7. Now switch to this branch and run `composer install-codestandards --verbose` again.
    ```
    Composer version 1.9.1 2019-11-01 17:20:17

    > install-codestandards: Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin::run
    Running PHPCodeSniffer Composer Installer
    Failed to set PHP CodeSniffer installed_paths Config
    ERROR: Config file I:\path\to\phpcodesniffer-composer-installer\vendor\squizlabs\php_codesniffer\CodeSniffer.conf is not writable
    ```
8. Run `echo $?` and take note of the exit code now being `1` (= failure).


Another test which tests another part of this change:
1. Follow steps 1 to 3 from above.
4. Now for the sake of testing this change, delete the `vendor/squizlabs/php_codesniffer` directory.
5. On `master`, run `composer install-codestandards --verbose`.
    The output will look something like:
    ```
    Composer version 1.9.1 2019-11-01 17:20:17

    > install-codestandards: Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin::run
    Running PHPCodeSniffer Composer Installer
    PHPCodeSniffer is not installed
    ```
6. Run `echo $?` and take note of the exit code being `0` (= success).
7. Now switch to this branch and run `composer install-codestandards --verbose` again.
    ```
    Composer version 1.9.1 2019-11-01 17:20:17

    > install-codestandards: Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin::run
    Running PHPCodeSniffer Composer Installer
    PHPCodeSniffer is not installed
    ```
8. Run `echo $?` and take note of the exit code now being `1` (= failure).
