### PR TITLE
Improve GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,7 +13,31 @@
 ## Steps to reproduce
 
 > (How can someone else make/see it happen)
+>
+> (Please include any relevant links. Think: links to a branch in a repo where you are experiencing the problem
+> which can be used to reproduce the issue, links to external standards you are using.)
+> (Also, if relevant and if it can be used to reproduce the issue, please paste the contents of your `composer.json`
+> file here.
+>
+> ```json
+> (Content of the `composer.json` file)
+> ```
 
 ## Proposed changes
 
 > (If you have a proposed change, workaround or fix, describe the rationale behind it)
+
+## Environment
+
+| Question               | Answer
+| ------------------------| -------
+| OS                                | Windows/Linux/Mac (preferably with some version info)
+| PHP version                       | x.y.z
+| Composer version                  | x.y.z
+| PHP_CodeSniffer version           | x.y.z
+| Dealerdirect PHPCS plugin version | x.y.z
+| Install type                      | e.g. Composer global, Composer project local, other (please expand)
+
+
+## Tested against `master` branch?
+- [ ] I have verified the issue still exists in the `master` branch.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
 ## Problem/Motivation
 
 > (Why the issue was filed)


### PR DESCRIPTION
## Proposed Changes

### Improve GH issue template

Add some additional guidance in an attempt to make sure that enough information will be added to issues to make them actionable.

### Move the issue template

Having a singular issue template named `.github/ISSUE_TEMPLATE.md` is using the legacy workflow from GitHub.
GitHub nowadays recommends for issue templates to be placed in a `ISSUE_TEMPLATE` directory and to use front matter, to allow for multiple descriptive issue templates.

Ref: https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates
