### PR TITLE
Adding linting jobs in github action

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,7 +1,10 @@
 ---
 name: Linting jobs
 
-on: [push]
+# yamllint disable-line rule:truthy
+on:
+  - push
+  - pull_request
 
 jobs:
   validate-composer:
@@ -42,3 +45,12 @@ jobs:
       - uses: actions/checkout@v1
       - name: Check markdown
         uses: pipeline-components/remark-lint@master
+
+  php-compitibility:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check php compatibility
+        uses: pipeline-components/php-codesniffer@master
+        with:
+          options: "-s -p --colors --extensions=php --standard=PHPCompatibility --runtime-set testVersion 5.3-7.4"

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -42,10 +42,3 @@ jobs:
       - uses: actions/checkout@v1
       - name: Check markdown
         uses: pipeline-components/remark-lint@master
-
-  php-security-checker:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v1
-      - name: Check php composer for security issues
-        uses: pipeline-components/php-security-checker@master

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,0 +1,51 @@
+---
+name: Linting jobs
+
+on: [push]
+
+jobs:
+  validate-composer:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate composer.json and composer.lock
+        uses: "docker://composer"
+        with:
+          args: "composer validate --no-check-lock"
+
+  lint-json:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Lint php
+        uses: "docker://pipelinecomponents/jsonlint:latest"
+        with:
+          args: "find . -not -path './.git/*' -name '*.json' -type f -exec jsonlint --quiet {} ;"
+
+  yamllint:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check yaml for issues
+        uses: pipeline-components/yamllint@master
+
+  php-codesniffer:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check php composer for security issues
+        uses: pipeline-components/php-codesniffer@master
+
+  lint-remark:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check markdown
+        uses: pipeline-components/remark-lint@master
+
+  php-security-checker:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Check php composer for security issues
+        uses: pipeline-components/php-security-checker@master

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    level: warning
+    max: 120


### PR DESCRIPTION
## Proposed Changes

Adding github actions for linting, because travis can be very slow, i want to run the basic checks in github actions. If that works for use i want to expand it till we no longer need/use travis

