### PR TITLE
Bugfix: Composer scripts/commands broken in 0.6.0 update

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -206,7 +206,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             }
         }
 
-        exit($exitCode);
+        return $exitCode;
     }
 
     /**


### PR DESCRIPTION
After the 0.6.0 update, Composer's `scripts/post-install-cmd` and `scripts/post-update-cmd` were no longer running.

This was due to PHP _exiting_ outright rather than _returning_ the `$exitCode`.