### PR TITLE
Allow installation on PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,13 @@ jobs:
       dist: precise
       env: PHPCS_VERSION="2.0.0"
 
+    - php: nightly
+      env: PHPCS_VERSION="dev-master" LINT=1
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
+
   fast_finish: true
 
 before_install:
@@ -93,7 +100,13 @@ install:
       # Install PHPCompatibility 8.x for PHPCS 2.2 < 2.3.
       composer require --no-update --no-suggest --no-scripts phpcompatibility/php-compatibility:"^8.0"
     fi
-  - travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
+  - |
+    if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+      travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
+    else
+      composer require --no-update --no-suggest --no-scripts phpcompatibility/php-compatibility
+      travis_wait composer install --no-dev --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose --ignore-platform-reqs
+    fi
   - |
     if [[ ${PHPCS_VERSION:0:3} < "2.2" ]]; then
       # Rename the PHPCompatibility directory as PHPCompatibility 7.x wasn't fully compatible with Composer yet.

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
   },
   "require": {
-    "php": "^5.3|^7",
+    "php": ">=5.3",
     "composer-plugin-api": "^1.0",
-    "squizlabs/php_codesniffer": "^2|^3"
+    "squizlabs/php_codesniffer": "^2 || ^3"
   },
   "require-dev": {
     "composer/composer": "*",


### PR DESCRIPTION
## Proposed Changes

As it was, the plugin when used by external standards, would block them from being tested on PHP 8.

As all the dependencies in the `require` section allow for PHP 8, there is no reason not to allow it.

The only dependencies currently in use which do not allow for PHP 8 yet are in the `require-dev` section. See the below output.

This includes updating the Travis script to:
* Only do a full (`dev`) install when not on `nightly`.
* Ignore platform requirements on `nightly` as otherwise the `dev` requirements would still block installation.
* And as PHPCompatibility is in the `require-dev` section, we need to require it explicitly for `nightly` to make sure the integration test can run.

As the Travis build on PHP `nightly` passes, I'm semi-confident that all should be good, though confidence will grow once we add more unit/integration tests.

```bash
# composer prohibits php:8

composer/composer          1.9.3   requires  php (^5.3.2 || ^7.0)
composer/semver            1.5.1   requires  php (^5.3.2 || ^7.0)
seld/jsonlint              1.7.2   requires  php (^5.3 || ^7.0)
symfony/console            v4.4.4  requires  php (^7.1.3)
symfony/filesystem         v4.4.4  requires  php (^7.1.3)
symfony/finder             v4.4.4  requires  php (^7.1.3)
symfony/process            v4.4.4  requires  php (^7.1.3)
symfony/service-contracts  v2.0.1  requires  php (^7.2.5)
```

