### PR TITLE
Test with PHPCS 4.x and allow installation when using PHPCS 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,12 +77,16 @@ jobs:
       dist: precise
       env: PHPCS_VERSION="2.0.0"
 
+    - php: 7.4
+      env: PHPCS_VERSION="4.0.x-dev as 3.9.99"
+
     - php: nightly
       env: PHPCS_VERSION="dev-master" LINT=1
 
   allow_failures:
     # Allow failures for unstable builds.
     - php: "nightly"
+    - env: PHPCS_VERSION="4.0.x-dev as 3.9.99"
 
   fast_finish: true
 
@@ -91,7 +95,7 @@ before_install:
   phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 
 install:
-  - composer require --no-update --no-suggest --no-scripts squizlabs/php_codesniffer:${PHPCS_VERSION}
+  - composer require --no-update --no-suggest --no-scripts squizlabs/php_codesniffer:"${PHPCS_VERSION}"
   - |
     if [[ ${PHPCS_VERSION:0:3} < "2.2" ]]; then
       # Install PHPCompatibility 7.x for PHPCS < 2.2.

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,15 @@
   "require": {
     "php": ">=5.3",
     "composer-plugin-api": "^1.0",
-    "squizlabs/php_codesniffer": "^2 || ^3"
+    "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
   },
   "require-dev": {
     "composer/composer": "*",
     "sensiolabs/security-checker": "^4.1.0",
     "phpcompatibility/php-compatibility": "^9.0"
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "autoload": {
     "psr-4": {
       "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"


### PR DESCRIPTION
## Proposed Changes

Development for PHPCS 4.x has started in a new `4.0` branch.

This PR is two-fold:

1. On the one hand, it adds testing against PHPCS 4.x to the Travis matrix as an early warning system in case any cross-version compatibility fixes would be needed for the plugin itself.
    The build against `4.x-dev` has been added to `allow_failures` for now.
    Note: as PHPCompatibility currently doesn't allow for PHPCS 4.x (yet), I'm aliasing the install to `3.9.99` for testing purposes in the Travis build only.
2. On the other hand, it allows installation in combination with PHPCS 4.x, which will in turn allow external standards which `require` this plugin, to start testing their standard against the PHPCS 4.x-dev branch.
    As it was now, external standards would get the plugin at version `0.4.4` as that's the last version with a PHPCS `*` constraint.

## Related Issues

* https://github.com/squizlabs/PHP_CodeSniffer/commits/4.0
