### PR TITLE
Support Composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require": {
     "php": ">=5.3",
-    "composer-plugin-api": "^1.0",
+    "composer-plugin-api": "^1.0 || ^2.0",
     "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
   },
   "require-dev": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -125,6 +125,20 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
      * Prepares the plugin so it's main functionality can be run.
      *
      * @throws \RuntimeException


### PR DESCRIPTION
## Proposed Changes

Minimal changes to updated the plugin to support Composer 2.0 which is expected late May/beginning of June.

Tested by @danepowell and myself (Windows 7). Further testing would be very welcome!

Fixes #108

@mjrider @Potherca Should this be added to the `0.6.3` or `0.7` milestone ?


## Related Issues

Changes are based on guidance found in:
* https://github.com/Dealerdirect/phpcodesniffer-composer-installer/issues/108
* https://github.com/composer/composer/issues/8726
* https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors
