### PR TITLE
Fixed v4 constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": ">=5.3",
     "composer-plugin-api": "^1.0 || ^2.0",
-    "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
+    "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
   },
   "require-dev": {
     "composer/composer": "*",


### PR DESCRIPTION
`4.0.x-dev` is the name of a branch, and not a version constraint. You should use a proper version constraint, otherwise anyone else who does use a one will find composer doesn't know what to do.