### PR TITLE
Add remark configuration

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "remark-preset-lint-recommended",
+    ["remark-lint-list-item-indent", "space"]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Note: This plugin is compatible with both version 2.x and 3.x of_ [PHP_CodeSnif
 
 ## Usage
 
-Installation can be done with [composer], by requiring this package as a development dependency:
+Installation can be done with [Composer][composer], by requiring this package as a development dependency:
 
 ```bash
 composer require --dev dealerdirect/phpcodesniffer-composer-installer
@@ -234,10 +234,8 @@ THE SOFTWARE.
 [composer]: https://getcomposer.org/
 [contributing-guidelines]: CONTRIBUTING.md
 [contributors]: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors
-[dealerdirectcom]: http://www.dealerdirect.com/en
 [definition-ci]: https://en.wikipedia.org/wiki/Continuous_integration
 [frenck]: https://github.com/frenck
-[get-in-touch]: https://www.dealerdirect.com/en/contact
 [last-updated-shield]: https://img.shields.io/github/last-commit/Dealerdirect/phpcodesniffer-composer-installer.svg
 [license-shield]: https://img.shields.io/github/license/dealerdirect/phpcodesniffer-composer-installer.svg
 [packagist-shield]: https://img.shields.io/packagist/dt/dealerdirect/phpcodesniffer-composer-installer.svg
@@ -251,4 +249,3 @@ THE SOFTWARE.
 [travis]: https://travis-ci.org/Dealerdirect/phpcodesniffer-composer-installer
 [tutorial]: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Coding-Standard-Tutorial
 [using-composer-plugins]: https://getcomposer.org/doc/articles/plugins.md#using-plugins
-[vacancies]: https://www.dealerdirect.com/en/vacancies


### PR DESCRIPTION
## Proposed Changes

This MR adds a configuration file for Remark, so there is now one consistent way Markdown should be written in this repo.
The configuration uses the `lint-recommended` preset, with as only exception that the `list-item-indent` has been set to only require a single space after a list character (as opposed to the multi-space default).

Other than a few links in the README, all markdown files in the repo already adhere to this standard.

As there is already a GitHub action that runs Remark, no other changes are needed.

## Related Issues

This MR is inspired by the comment from @jrfnl in #118 regarding inconsistencies in my Markdown.
I suggested adding a Remark config, so here it is! :grin: 