### PR TITLE
Travis: add build against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,12 @@ jobs:
         - composer validate
 
     - stage: test
-      php: 7.4
+      php: 8.0
+      env: PHPCS_VERSION="dev-master" LINT=1
+    - php: 8.0
+      # Lowest PHPCS version on which PHP 8.0 is supported.
+      env: PHPCS_VERSION="3.5.7"
+    - php: 7.4
       env: PHPCS_VERSION="dev-master" LINT=1
     - php: 7.4
       # Lowest PHPCS version on which PHP 7.4 is supported.
@@ -105,7 +110,7 @@ install:
       composer require --no-update --no-suggest --no-scripts phpcompatibility/php-compatibility:"^8.0"
     fi
   - |
-    if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+    if [[ $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != "8.0" ]]; then
       travis_wait composer install --no-interaction --no-progress --no-scripts --no-suggest --optimize-autoloader --prefer-dist --verbose
     else
       composer require --no-update --no-suggest --no-scripts phpcompatibility/php-compatibility


### PR DESCRIPTION
## Proposed Changes

PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds two new builds against PHP 8.0 to the matrix and, as PHP 8.0 has been released, these builds are not allowed to fail.
