### PR TITLE
Sort list of installed paths before saving for consistency

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -267,6 +267,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         // Check if we found installed paths to set.
         if (count($this->installedPaths) !== 0) {
+            sort($this->installedPaths);
             $paths = implode(',', $this->installedPaths);
             $arguments = array('--config-set', self::PHPCS_CONFIG_KEY, $paths);
             $configMessage = sprintf(


### PR DESCRIPTION
## Proposed Changes

> Fixes the inconsistency in `installed_paths` documented in #125 by sorting the list of installed paths alphabetically before saving them.

## Related Issues

> #125 
