### PR TITLE
Stabilize a condition

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -410,7 +410,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
             if (
                 (is_dir($path) === false || is_readable($path) === false) &&
-                (is_dir($alternativePath) === false || is_readable($alternativePath) === false)
+                (
+                    $alternativePath === false ||
+                    is_dir($alternativePath) === false ||
+                    is_readable($alternativePath) === false
+                )
             ) {
                 unset($this->installedPaths[$key]);
                 $changes = true;


### PR DESCRIPTION
## Proposed Changes

While looking into the (non-)race condition described in #125, I noticed a potentially related issue.

As per the documentation of [realpath()](https://www.php.net/manual/en/function.realpath.php#refsect1-function.realpath-returnvalues):
> realpath() returns FALSE on failure, e.g. if the file does not exist.

In the rare case that `realpath()` _would_ return `false` within this plugin, `false` would subsequently be passed on to `is_dir()` and `is_readable()` which both expect a string path.

This tiny change makes the condition fail earlier by checking the return value of `realpath()`.

