### PR TITLE
GH Actions: PHP 8.1 has been released

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         phpcs_version: ['dev-master']
         phpcompat: ['composer']
         experimental: [false]
@@ -30,6 +30,11 @@ jobs:
 
           # Complement the matrix with build against the lowest supported PHPCS version
           # for each PHP version.
+          - php: '8.1'
+            # Lowest PHPCS version on which PHP 8.1 is supported.
+            phpcs_version: '3.6.1'
+            phpcompat: 'composer'
+            experimental: false
           - php: '8.0'
             # Lowest PHPCS version on which PHP 8.0 is supported.
             phpcs_version: '3.5.7'
@@ -118,12 +123,12 @@ jobs:
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.1'
+          - php: '8.2'
             phpcs_version: 'dev-master'
             phpcompat: 'composer'
             experimental: true
 
-          - php: '8.0'
+          - php: '8.1'
             phpcs_version: '4.0.x-dev as 3.9.99'
             phpcompat: 'composer'
             experimental: true

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require-dev": {
     "composer/composer": "*",
     "phpcompatibility/php-compatibility": "^9.0",
-    "php-parallel-lint/php-parallel-lint": "^1.3"
+    "php-parallel-lint/php-parallel-lint": "^1.3.1"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
## Proposed Changes

* No longer allow builds against PHP 8.1 to fail.
* Add a dedicated build against PHP 8.1 in combination with the lowest PHPCS version which supports it (runtime support).
* Change the experimental `nightly` build to use PHP 8.2.

Includes updating the version constraint for the PHP Parallel Lint tool to have the minimum version set to a version which supports PHP 8.1.