### PR TITLE
CI: various updates

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -151,7 +151,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: error_reporting=E_ALL, display_errors=On
+          ini-values: error_reporting=-1, display_errors=On
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -155,12 +155,12 @@ jobs:
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       # Install PHPCompatibility 7.x/8.x for PHPCS < 2.3.
       - name: 'Composer: set PHPCompatibility version for tests (PHPCS < 2.3)'
         if: ${{ matrix.phpcompat != 'composer' }}
-        run: composer require --dev --no-update --no-scripts phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}"
+        run: composer require --dev --no-update --no-scripts phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -165,7 +165,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: 'Install Composer dependencies'
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --no-scripts --optimize-autoloader
 

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -17,7 +17,7 @@ jobs:
   validate-composer:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Validate composer.json and composer.lock
         uses: "docker://composer"
         with:
@@ -26,7 +26,7 @@ jobs:
   lint-json:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Lint json
         uses: "docker://pipelinecomponents/jsonlint:latest"
         with:
@@ -35,20 +35,20 @@ jobs:
   yamllint:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Check yaml for issues
         uses: pipeline-components/yamllint@master
 
   php-codesniffer:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Check php for code style and php cross-version compatibility issues
         uses: pipeline-components/php-codesniffer@master
 
   lint-remark:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Check markdown
         uses: pipeline-components/remark-lint@master

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -7,6 +7,12 @@ on:
   - pull_request
   - workflow_dispatch
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-composer:
     runs-on: ubuntu-18.04

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -8,6 +8,12 @@ on:
   # Allow manually triggering the workflow.
   - workflow_dispatch
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phplint:
     runs-on: ubuntu-latest

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -38,7 +38,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -9,6 +9,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the integration tests against a limited set of

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -55,12 +55,12 @@ jobs:
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'
-        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}"
+        run: composer require --no-update --no-scripts squizlabs/php_codesniffer:"${{ matrix.phpcs_version }}" --no-interaction
 
       # Install PHPCompatibility 7.x/8.x for PHPCS < 2.3.
       - name: 'Composer: set PHPCompatibility version for tests (PHPCS < 2.3)'
         if: ${{ matrix.phpcompat != 'composer' }}
-        run: composer require --dev --no-update --no-scripts phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}"
+        run: composer require --dev --no-update --no-scripts phpcompatibility/php-compatibility:"${{ matrix.phpcompat }}" --no-interaction
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -51,7 +51,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          ini-values: error_reporting=E_ALL, display_errors=On
+          ini-values: error_reporting=-1, display_errors=On
           coverage: none
 
       - name: 'Composer: set PHPCS version for tests'

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -65,7 +65,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: 'Install Composer dependencies'
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --no-scripts --optimize-autoloader
 

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -36,7 +36,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Download security checker
         run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v1.2.0/local-php-security-checker_1.2.0_linux_amd64

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -39,10 +39,10 @@ jobs:
         uses: "ramsey/composer-install@v1"
 
       - name: Download security checker
-        run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_amd64
+        run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v1.2.0/local-php-security-checker_1.2.0_linux_amd64
 
       - name: Make security checker executable
-        run: chmod +x ./local-php-security-checker_1.0.0_linux_amd64
+        run: chmod +x ./local-php-security-checker_1.2.0_linux_amd64
 
       - name: Check against insecure dependencies
-        run: ./local-php-security-checker_1.0.0_linux_amd64 --path=composer.lock
+        run: ./local-php-security-checker_1.2.0_linux_amd64 --path=composer.lock

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -8,6 +8,12 @@ on:
   # Allow manually triggering the workflow.
   - workflow_dispatch
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   security-check:
     runs-on: ubuntu-latest

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,7 +34,6 @@ use Symfony\Component\Process\PhpExecutableFinder;
  */
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
-
     const KEY_MAX_DEPTH = 'phpcodesniffer-search-depth';
 
     const MESSAGE_ERROR_WRONG_MAX_DEPTH =


### PR DESCRIPTION
### CS: minor cleanup

PHPCS 3.6.2 added a sniff for a PSR-12 rule which was previously not strictly checked: "No blank line after the opening brace of a class".

This fixes the newly flagged issues.

### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: use error_reporting=-1

... as `E_ALL` does not always contain _all_ errors across PHP versions.

### GH Actions: update the security checker

Ref: https://github.com/fabpot/local-php-security-checker/blob/main/CHANGELOG.md

### 🆕 GH Actions: version update for `ramsey/composer-install`

The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2

### 🆕 GH Actions: always use --no-interaction for Composer

Adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

### 🆕 🆕 GH Actions: version update for `actions/checkout`

Ref: https://github.com/actions/checkout/releases