### PR TITLE
Change YamlLint config to prevent "truthy" warning.

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,8 @@
 ---
 extends: default
+
 rules:
   line-length:
     level: warning
     max: 120
+  truthy: {allowed-values: ["true", "false", "on"]}


### PR DESCRIPTION
This MR adds a config rule to the Yaml Lint config to prevent the warning

> truthy value should be one of [false, true]

to occur in GitHub Action files for the key `on`.

This should cut down on false positives. Line-lenght warnings still need to be resolved.