### PR TITLE
Composer: tweak PHPCS version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": ">=5.3",
     "composer-plugin-api": "^1.0 || ^2.0",
-    "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+    "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
   },
   "require-dev": {
     "composer/composer": "*",


### PR DESCRIPTION
## Proposed Changes

Some of the early PHPCS 3.x versions did not support external standards correctly, so using this plugin with those would always run into trouble, so let's just make it explicit that `3.0.0` and `3.0.1` are not supported.

`3.0.2` should be fine, though IIRC, even `3.1.0` contained some fixes for external standard support, so we could choose to up this to `^3.1.0` to be on the safe side.


