### PR TITLE
Plugin::loadInstalledPaths(): `config-show` always shows all

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -233,10 +233,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         if ($this->isPHPCodeSnifferInstalled() === true) {
             $this->processExecutor->execute(
-                sprintf(
-                    'phpcs --config-show %s',
-                    self::PHPCS_CONFIG_KEY
-                ),
+                'phpcs --config-show',
                 $output,
                 $this->composer->getConfig()->get('bin-dir')
             );


### PR DESCRIPTION
## Proposed Changes

Running PHPCS with `--config-show installed_paths` is an unsupported command for PHPCS. The `--config-show` command does not take additional parameters and will always show all keys.

While PHPCS is currently tolerant of this, there is no guarantee that it will continue to stay tolerant of this.
